### PR TITLE
Add __toString() method.

### DIFF
--- a/finediff.php
+++ b/finediff.php
@@ -220,6 +220,15 @@ class FineDiff {
 		$this->doDiff($from_text, $to_text);
 		}
 
+	/**
+	* Magic __toString() method
+	* ...
+	* Assuming `$diff = new FineDiff($from, $to);`, `echo $diff` will print the HTML diff.
+	*/
+	public function __toString(){
+		return $this->renderDiffToHTML();
+		}
+
 	public function getOps() {
 		return $this->edits;
 		}


### PR DESCRIPTION
Currently, it takes a bit of digging to find the correct functions to use, and the following code causes an error:

```
<?php
$diff = new FineDiff($from, $to);
echo $diff;
?>
```

However, adding the magic `__toString()` method makes this return the HTML diff (as I, using it for the first time, assumed would occur).
